### PR TITLE
Change the dust size to use the standard 5430 satoshis

### DIFF
--- a/Chrome Extension/issueticker-wt.js
+++ b/Chrome Extension/issueticker-wt.js
@@ -223,7 +223,7 @@ $( document ).ready(function() {
         
         var quantity = amount;
         
-        var btc_total = 0.0000547;  //total btc to receiving address
+        var btc_total = 0.0000543;  //total btc to receiving address
         var msig_total = 0.000078;  //total btc to multisig output (returned to sender)
 
         var transfee = 0.0001;  //bitcoin tx fee

--- a/Chrome Extension/issueticker.js
+++ b/Chrome Extension/issueticker.js
@@ -224,7 +224,7 @@ $( document ).ready(function() {
         
         var quantity = amount;
         
-        var btc_total = 0.0000547;  //total btc to receiving address
+        var btc_total = 0.0000543;  //total btc to receiving address
         var msig_total = 0.000078;  //total btc to multisig output (returned to sender)
 
         var transfee = 0.0001;  //bitcoin tx fee

--- a/Chrome Extension/js/glidera.js
+++ b/Chrome Extension/js/glidera.js
@@ -638,7 +638,7 @@ if (!glidera) {
 					//console.log("user/create_sell_address success: " + JSON.stringify(data));
 					var transaction = new bitcore.Transaction().to(data['sellAddress'], bitcore.Unit.fromBTC(amountToSend).toSatoshis()).change(fromAddress);
 					if (transaction._hasDustOutputs()) {
-						glidera.addMessage('alert-danger', null, "The bitcoin amount is too small, you must sell at least " + glidera.formatBTC(0.00000547));
+						glidera.addMessage('alert-danger', null, "The bitcoin amount is too small, you must sell at least " + glidera.formatBTC(0.00000543));
 						return;
 					}
 					var bitpayUtxo = "https://" + (getNetwork().name === 'testnet' ? 'test-' : '') + INSIGHT_SERVER + "/api/addr/" + fromAddress + "/utxo";

--- a/Chrome Extension/popup.js
+++ b/Chrome Extension/popup.js
@@ -312,7 +312,7 @@ function qrdepositDropdown() {
             
             var currentaddr = $("#xcpaddress").html();
             
-            $("#btcbalance").html("Deposit bitcoin for transaction fees<div style='margin: 20px 0 10px 0; font-size: 10px; font-weight: bold;'>"+currentaddr+"</div><div id='btcqr' style='margin: 10px auto 20px auto; height: 100px; width: 100px;'></div><div>Cost per transaction is 0.00015470 BTC</div></div>");
+            $("#btcbalance").html("Deposit bitcoin for transaction fees<div style='margin: 20px 0 10px 0; font-size: 10px; font-weight: bold;'>"+currentaddr+"</div><div id='btcqr' style='margin: 10px auto 20px auto; height: 100px; width: 100px;'></div><div>Cost per transaction is 0.00015430 BTC</div></div>");
                                   
             var qrcode = new QRCode(document.getElementById("btcqr"), {
     			text: currentaddr,
@@ -351,7 +351,7 @@ function getBTCBalance(pubkey) {
         
         //var transactions = (parseFloat(data) / 15470) ; //insight
         //var transactions = (parseFloat(data.data.confirmed_balance) + parseFloat(data.data.unconfirmed_balance))/ 0.0001547; //chainso
-        var transactions = (parseFloat(apidata.data.balance) / 0.0001547) ; //blockr
+        var transactions = (parseFloat(apidata.data.balance) / 0.0001543) ; //blockr
         
         if (transactions < 1) {
             transactions = 0;
@@ -1520,7 +1520,7 @@ function sendtokenaction() {
                         
                         } else if (txsAvailable > 1) {
                             
-                            var btc_total = 0.0000547;  //total btc to receiving address
+                            var btc_total = 0.0000543;  //total btc to receiving address
                             var msig_total = 0.000078;  //total btc to multisig output (returned to sender)
                             var mnemonic = $("#newpassphrase").html();
                             

--- a/Chrome Extension/test/asset_send.html
+++ b/Chrome Extension/test/asset_send.html
@@ -29,7 +29,7 @@ $( document ).ready(function() {
         var asset = $("#asset").val();
         var asset_total = $("#asset_total").val();
         
-        var btc_total = 0.0000547;  //total btc to receiving address
+        var btc_total = 0.0000543;  //total btc to receiving address
         var msig_total = 0.000078;  //total btc to multisig output (returned to sender)
 
         var transfee = 0.0001;  //bitcoin tx fee

--- a/Chrome Extension/ticker.js
+++ b/Chrome Extension/ticker.js
@@ -478,7 +478,7 @@ $( document ).ready(function() {
         } else {
       
             var currentaddr = $("#xcpaddress").html();
-            $("#btcbalance").append("<div id='moreBTCinfo'><div style='margin: 20px 0 10px 0; font-size: 10px; font-weight: bold;'>"+currentaddr+"</div><div id='btcqr' style='margin: 10px auto 20px auto; height: 100px; width: 100px;'></div><div>Cost per transaction is 0.0001547 BTC</div></div>");  
+            $("#btcbalance").append("<div id='moreBTCinfo'><div style='margin: 20px 0 10px 0; font-size: 10px; font-weight: bold;'>"+currentaddr+"</div><div id='btcqr' style='margin: 10px auto 20px auto; height: 100px; width: 100px;'></div><div>Cost per transaction is 0.0001543 BTC</div></div>");  
             var qrcode = new QRCode(document.getElementById("btcqr"), {
     			text: currentaddr,
     			width: 100,
@@ -1190,7 +1190,7 @@ $(document).on('click', '#toolsTab', function () {
 
                     var description = "BVAMWT-"+hash;
 
-                    var btc_total = 0.0000547;  //total btc to receiving address
+                    var btc_total = 0.0000543;  //total btc to receiving address
                     var msig_total = 0.000078;  //total btc to multisig output (returned to sender)
 
                     var transfee = 0.0001;  //bitcoin tx fee

--- a/Chrome Extension/tipsplash.js
+++ b/Chrome Extension/tipsplash.js
@@ -413,7 +413,7 @@ function getBTCBalance(pubkey, callback) {
         
         //var transactions = (parseFloat(data) / 15470) ; //insight
         //var transactions = (parseFloat(data.data.confirmed_balance) + parseFloat(data.data.unconfirmed_balance))/ 0.0001547; //chainso
-        var transactions = (parseFloat(apidata.data.balance) / 0.0001547) ; //blockr
+        var transactions = (parseFloat(apidata.data.balance) / 0.0001543) ; //blockr
         
         if (transactions < 1) {
             transactions = 0;
@@ -542,7 +542,7 @@ function sendtokenaction() {
                         
                             } else {
                             
-                                var btc_total = 0.0000547;  //total btc to receiving address
+                                var btc_total = 0.0000543;  //total btc to receiving address
                                 var minersfee = 0.0001;
                                 var mnemonic = $("#passphrasefromstorage").html();
 


### PR DESCRIPTION
Swapbots will choose UTXOs with exactly 5430 satoshis in order to construct swap transactions that require no change transactions.  This creates smaller transactions, gives better confirmation times for users and will ultimately allow us to use lower fees on outbound swaps.

If Pockets sends UTXOs with 5470 satoshis, then more swaps will generate change UTXOs when these are spent due to the extra 40 satoshis that need to be sent back as change.
